### PR TITLE
Add PDF text extraction utility with OCR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # stage
-file_finder_alpha
+
+A tiny utility to extract text from PDF files. It first attempts to read embedded
+text and falls back to OCR for scanned pages.
+
+## Setup
+
+1. Install the Python dependencies:
+   ```bash
+   pip install pymupdf pytesseract pillow
+   ```
+2. Install the Tesseract OCR engine (example for Debian/Ubuntu):
+   ```bash
+   sudo apt-get install tesseract-ocr
+   ```
+
+## Usage
+
+```bash
+python pdf_reader.py path/to/document.pdf
+```
+
+The extracted text is printed to standard output.

--- a/pdf_reader.py
+++ b/pdf_reader.py
@@ -1,0 +1,39 @@
+import io
+from typing import List
+
+import fitz  # PyMuPDF
+import pytesseract
+from PIL import Image
+
+
+def extract_pdf_text(pdf_path: str) -> str:
+    """Extract text from a PDF, using OCR for image-only pages.
+
+    Args:
+        pdf_path: Path to the PDF file.
+
+    Returns:
+        The extracted text as a single string.
+    """
+    text_parts: List[str] = []
+    with fitz.open(pdf_path) as doc:
+        for page in doc:
+            text = page.get_text().strip()
+            if text:
+                text_parts.append(text)
+            else:
+                pix = page.get_pixmap()
+                img = Image.open(io.BytesIO(pix.tobytes("png")))
+                ocr_text = pytesseract.image_to_string(img).strip()
+                text_parts.append(ocr_text)
+    return "\n".join(filter(None, text_parts))
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Extract text from PDFs with OCR fallback.")
+    parser.add_argument("pdf", help="Path to the PDF file")
+    args = parser.parse_args()
+
+    print(extract_pdf_text(args.pdf))


### PR DESCRIPTION
## Summary
- add `pdf_reader.py` to extract text from PDFs with an OCR fallback for image-only pages
- document setup and usage in README

## Testing
- `python pdf_reader.py text.pdf`
- `python pdf_reader.py scan.pdf`


------
https://chatgpt.com/codex/tasks/task_b_68aec253eef48332a9f8a3ec39934b96